### PR TITLE
Log SHA256 of files instead of MD5

### DIFF
--- a/honssh/output.py
+++ b/honssh/output.py
@@ -233,7 +233,7 @@ class Output():
         channelName, uuid, success, link, file, error = input
         if success:
             if self.cfg.get('txtlog', 'enabled') == 'true':
-                threads.deferToThread(self.generateMD5, channelName, dt, self.cfg.get('folders', 'log_path') + '/downloads.log', self.endIP, link, file)
+                threads.deferToThread(self.generateSHA256, channelName, dt, self.cfg.get('folders', 'log_path') + '/downloads.log', self.endIP, link, file)
                 
             if self.cfg.get('database_mysql', 'enabled') == 'true':
                 self.dbLog.handleFileDownload(dt, uuid, link, file)
@@ -386,20 +386,20 @@ class Output():
         country = geo.country_name_by_addr(ipv4_str)
         return country
     
-    def generateMD5(self, channelName, dt, logPath, theIP, link, outFile):      
+    def generateSHA256(self, channelName, dt, logPath, theIP, link, outFile):
         f = file(outFile, 'rb')
-        md5 = hashlib.md5()
+        sha256 = hashlib.sha256()
         while True:
             data = f.read(2**20)
             if not data:
                 break
-            md5.update(data)
+            sha256.update(data)
         f.close()
         
-        theMD5 = md5.hexdigest()
+        theSHA256 = sha256.hexdigest()
         theSize = os.path.getsize(outFile)
-        txtlog.log(dt, self.txtlog_file, channelName + ' Downloaded: ' + link + ' - Saved: ' + outFile + ' - Size: ' + str(theSize) + ' - MD5: ' + str(theMD5))
-        txtlog.downloadLog(dt, logPath, theIP, link, outFile, theSize, theMD5)
+        txtlog.log(dt, self.txtlog_file, channelName + ' Downloaded: ' + link + ' - Saved: ' + outFile + ' - Size: ' + str(theSize) + ' - SHA256: ' + str(theSHA256))
+        txtlog.downloadLog(dt, logPath, theIP, link, outFile, theSize, theSHA256)
     
     def wget(self, channelName, uuid, link, fileOut, user, password):
         response = False

--- a/honssh/txtlog.py
+++ b/honssh/txtlog.py
@@ -65,14 +65,14 @@ def authLog(dt, logfile, ip, username, password, success):
     if(setPermissions):
         os.chmod(logfile, 0644)
         
-def downloadLog(dt, logfile, ip, link, outFile, theSize, theMD5):
+def downloadLog(dt, logfile, ip, link, outFile, theSize, theSHA256):
     setPermissions = False
     
     if(os.path.isfile(logfile) == False):
         setPermissions = True
       
     f = file(logfile, 'a')
-    f.write("%s,%s,%s,%s,%s,%s\n" % (dt, ip, link, theSize, theMD5, outFile))
+    f.write("%s,%s,%s,%s,%s,%s\n" % (dt, ip, link, theSize, theSHA256, outFile))
     f.close()
     
     if(setPermissions):


### PR DESCRIPTION
MD5 has collisions http://www.kernelmode.info/forum/viewtopic.php?f=2&t=3262&start=10
and I think its more covenient to use sha256 for example in

virustotal.com/en/file/"sha256"/analysis