### PR TITLE
Also remove chars ( and ) when parsing commands

### DIFF
--- a/honssh/output.py
+++ b/honssh/output.py
@@ -181,7 +181,7 @@ class Output():
         if self.cfg.get('hpfeeds', 'enabled') == 'true':
             self.hpLog.handleCommand(dt, uuid, theCommand)
             
-        theCommandsSplit = re.findall(r'(?:[^;&|<>"\']|["\'](?:\\.|[^"\'])*[\'"])+', theCommand)
+        theCommandsSplit = re.findall(r'(?:[^;&|<>()"\']|["\'](?:\\.|[^"\'])*[\'"])+', theCommand)
         theCMDs = []
         
         for cmd in theCommandsSplit:


### PR DESCRIPTION
hello, parsed commands,

situation now:
(sh curl0.sh
)

situation with this commit:
sh curl0.sh


