### PR TITLE
Ignore generated dir and files by honSSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+sessions/
+logs/
+users.cfg
+honssh.cfg
+id_rsa
+id_rsa.pub
+id_dsa
+id_dsa.pub
+honssh.pid


### PR DESCRIPTION
Adding a `.gitignore` to ignore generated directories and files generated by honSSH after launch.